### PR TITLE
Add prodist() method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,30 +1,23 @@
 Package: gamlss
-Description: Functions for fitting the Generalized Additive Models for Location Scale and Shape introduced by Rigby and Stasinopoulos (2005), <doi:10.1111/j.1467-9876.2005.00510.x>. The models use a distributional regression approach where all the parameters of the conditional distribution of the response variable are modelled using explanatory variables.
+Title: Generalized Additive Models for Location Scale and Shape
 Version: 5.4-14
-Date: 2023-07-11
+Date: 2023-08-01
 Authors@R: c(person("Mikis", "Stasinopoulos", role = c("aut", "cre", "cph"), 
-             email = "d.stasinopoulos@londonmet.ac.uk"),
-           person("Bob", "Rigby", role = c("aut")), 
-           person("Vlasios", "Voudouris", role = "ctb"),  
+           email = "d.stasinopoulos@londonmet.ac.uk", comment = c(ORCID = "0000-0003-2407-5704")),
+           person("Robert", "Rigby", role = "aut", email = "r.rigby@londonmet.ac.uk", comment = c(ORCID = "0000-0003-3853-1707")),
+           person("Vlasios", "Voudouris", role = "ctb"),
            person("Calliope", "Akantziliotou", role = "ctb"),
            person("Marco", "Enea", role = "ctb"),
-           person("Daniil", "Kiose", role = "ctb") 
+           person("Daniil", "Kiose", role = "ctb", comment = c(ORCID = "0000-0002-3596-5748")),
+           person("Achim", "Zeileis", role = "ctb", email = "Achim.Zeileis@R-project.org", comment = c(ORCID = "0000-0003-0918-3766"))
            )
-Title: Generalised Additive Models for Location Scale and Shape
-Maintainer: Mikis Stasinopoulos <d.stasinopoulos@londonmet.ac.uk>
-Depends: R (>= 3.3.0), graphics, stats, splines, utils, grDevices,
-        gamlss.data (>= 5.0-0), gamlss.dist (>= 4.3.1), nlme, parallel
-LazyLoad: yes
-Imports: MASS, survival, methods
+Description: Functions for fitting the Generalized Additive Models for Location Scale and Shape introduced by Rigby and Stasinopoulos (2005), <doi:10.1111/j.1467-9876.2005.00510.x>. The models use a distributional regression approach where all the parameters of the conditional distribution of the response variable are modelled using explanatory variables.
 License: GPL-2 | GPL-3
 URL: https://www.gamlss.com/
+BugReports: https://github.com/mstasinopoulos/GAMLSS-original/issues
+Depends: R (>= 3.3.0), graphics, stats, splines, utils, grDevices,
+        gamlss.data (>= 5.0-0), gamlss.dist (>= 4.3.1), nlme, parallel
+Imports: MASS, survival, methods
+Suggests: distributions3 (>= 0.2.1)
+LazyLoad: yes
 NeedsCompilation: yes
-Packaged: 2020-09-10 11:45:48 UTC; dimitriosstasinopoulos
-Author: Mikis Stasinopoulos [aut, cre, cph],
-  Bob Rigby [aut],
-  Vlasios Voudouris [ctb],
-  Calliope Akantziliotou [ctb],
-  Marco Enea [ctb],
-  Daniil Kiose [ctb]
-Repository: CRAN
-Date/Publication: 2020-09-12 06:40:02 UTC

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Title: Generalized Additive Models for Location Scale and Shape
 Version: 5.4-14
 Date: 2023-08-01
 Authors@R: c(person("Mikis", "Stasinopoulos", role = c("aut", "cre", "cph"), 
-           email = "d.stasinopoulos@londonmet.ac.uk", comment = c(ORCID = "0000-0003-2407-5704")),
-           person("Robert", "Rigby", role = "aut", email = "r.rigby@londonmet.ac.uk", comment = c(ORCID = "0000-0003-3853-1707")),
+           email = "d.stasinopoulos@gre.ac.uk", comment = c(ORCID = "0000-0003-2407-5704")),
+           person("Robert", "Rigby", role = "aut", email = "r.rigby@gre.ac.uk", comment = c(ORCID = "0000-0003-3853-1707")),
            person("Vlasios", "Voudouris", role = "ctb"),
            person("Calliope", "Akantziliotou", role = "ctb"),
            person("Marco", "Enea", role = "ctb"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -153,6 +153,6 @@ S3method(print, pbc)
 #-------------------------
 S3method(print, cy)
 
-
+S3method(distributions3::prodist, gamlss)
 
 useDynLib(gamlss, .registration = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,14 @@
+# Version 5.4-14
+
+* The package is now hosted on GitHub at
+  <https://github.com/mstasinopoulos/GAMLSS-original/>.
+
+* Add a new `prodist()` method for extracting fitted (in-sample) or predicted
+  (out-of-sample) probability distributions from gamlss models (contributed by
+  [Achim Zeileis](https://www.zeileis.org/)). This enables the workflow from the
+  [distributions3](https://CRAN.R-project.org/package=distributions3) for all
+  distributions provided by `gamlss.dist`. The idea is that the `distributions3`
+  objects encapsulate all information needed to obtain moments (mean, variance,
+  etc.), probabilities, quantiles, etc. with a unified interface. See the
+  [useR! 2022 presentation](https://www.zeileis.org/news/user2022/) by
+  Zeileis, Lang, and Hayes for an overview.

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -1,0 +1,8 @@
+## S3 method for extracting fitted/predicted distributions3 objects
+## associated methods are in gamlss.dist (as well as distributions3, topmodels, etc.)
+prodist.gamlss <- function(object, ...) {
+  d <- predictAll(object, ...)
+  d$y <- NULL
+  class(d) <- c("GAMLSS", "distribution")
+  return(d)  
+}

--- a/man/prodist.gamlss.Rd
+++ b/man/prodist.gamlss.Rd
@@ -1,0 +1,107 @@
+\name{prodist.gamlss}
+
+\alias{prodist.gamlss}
+
+\title{Extracting Fitted or Predicted Probability Distributions from gamlss Models}
+
+\description{
+Methods for \pkg{gamlss} model objects for extracting fitted (in-sample) or
+predicted (out-of-sample) probability distributions as \pkg{distributions3}
+objects.
+}
+
+\usage{
+\method{prodist}{gamlss}(object, ...)
+}
+\arguments{
+  \item{object}{A model object of class \code{\link{gamlss}}.}
+  \item{...}{Arguments passed on to \code{\link{predictAll}}, e.g., \code{newdata}.}
+}
+
+\details{
+To facilitate making probabilistic forecasts based on \code{\link{gamlss}}
+model objects, the \code{\link[distributions3]{prodist}} method extracts fitted
+or predicted probability \code{distribution} objects. Internally, the
+\code{\link{predictAll}} method is used first to obtain the distribution
+parameters (\code{mu}, \code{sigma}, \code{tau}, \code{nu}, or a subset thereof).
+Subsequently, the corresponding \code{distribution} object is set up using the
+\code{\link[gamlss.dist]{GAMLSS}} class from the \pkg{gamlss.dist} package,
+enabling the workflow provided by the \pkg{distributions3} package (see Zeileis
+et al. 2022).
+
+Note that these probability distributions only reflect the random variation in
+the dependent variable based on the model employed (and its associated
+distributional assumption for the dependent variable). This does not capture the
+uncertainty in the parameter estimates.
+}
+
+\value{
+An object of class \code{GAMLSS} inheriting from \code{distribution}.
+}
+
+\references{
+Zeileis A, Lang MN, Hayes A (2022).
+\dQuote{distributions3: From Basic Probability to Probabilistic Regression.}
+Presented at \emph{useR! 2022 - The R User Conference}.
+Slides, video, vignette, code at \url{https://www.zeileis.org/news/user2022/}.
+}
+
+\seealso{
+\code{\link[gamlss.dist]{GAMLSS}}, \code{\link{predictAll}}
+}
+
+\examples{
+\dontshow{ if(!requireNamespace("distributions3")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("not all packages required for the example are installed")
+  } else q() }
+}
+## packages, code, and data
+library("gamlss")
+library("distributions3")
+data("cars", package = "datasets")
+
+## fit heteroscedastic normal GAMLSS model
+## stopping distance (ft) explained by speed (mph)
+m <- gamlss(dist ~ pb(speed), ~ pb(speed), data = cars, family = "NO")
+
+## obtain predicted distributions for three levels of speed
+d <- prodist(m, newdata = data.frame(speed = c(10, 20, 30)))
+print(d)
+
+## obtain quantiles (works the same for any distribution object 'd' !)
+quantile(d, 0.5)
+quantile(d, c(0.05, 0.5, 0.95), elementwise = FALSE)
+quantile(d, c(0.05, 0.5, 0.95), elementwise = TRUE)
+
+## visualization
+plot(dist ~ speed, data = cars)
+nd <- data.frame(speed = 0:240/4)
+nd$dist <- prodist(m, newdata = nd)
+nd$fit <- quantile(nd$dist, c(0.05, 0.5, 0.95))
+matplot(nd$speed, nd$fit, type = "l", lty = 1, col = "slategray", add = TRUE)
+
+## moments
+mean(d)
+variance(d)
+
+## simulate random numbers
+random(d, 5)
+
+## density and distribution
+pdf(d, 50 * -2:2)
+cdf(d, 50 * -2:2)
+
+## Poisson example
+data("FIFA2018", package = "distributions3")
+m2 <- gamlss(goals ~ pb(difference), data = FIFA2018, family = "PO")
+d2 <- prodist(m2, newdata = data.frame(difference = 0))
+print(d2)
+quantile(d2, c(0.05, 0.5, 0.95))
+
+## note that log_pdf() can replicate logLik() value
+sum(log_pdf(prodist(m2), FIFA2018$goals))
+logLik(m2)
+}
+
+\keyword{distribution}


### PR DESCRIPTION
Accompanying the addition of the [GAMLSS class based on distributions3](https://github.com/mstasinopoulos/GAMLSS-Distibutions/pulls) in `gamlss.dist` I have added a `prodist()` method for `gamlss` objects here. This greatly facilitates the entire workflow as illustrated on the corresponding manual page `?prodist.gamlss`.

As for `gamlss.dist` I have streamlined the `DESCRIPTION` a bit (adding myself as a contributor, and linking to GitHub for bug reports) and added a `NEWS.md` (which only makes sense if you keep this up-to-date in the future). Please consider everything as a proposal only and let me know if I should add, modify, or undo anything!

Thanks in advance for your consideration!

P.S.: `R CMD check` produces a NOTE (regarding `quantile.weights` which is misinterpreted as an S3 method) and a WARNING (regarding undocumented objects starting with a period: `.binom`, `.counts`, ...). These seem unrelated to my changes, though. Also, they don't appear in the current CRAN release but I didn't dig deeper.